### PR TITLE
Setup nextjs for static site building

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,11 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  output: 'export',
+  distDir: 'build',
   reactStrictMode: true,
+  images: {
+    unoptimized: true,
+  },
 }
 
 module.exports = nextConfig


### PR DESCRIPTION
In the future, we would like to support a non-static page server so we can run things like [arooo](https://www.google.com/url?sa=t&rct=j&q=&esrc=s&source=web&cd=&cad=rja&uact=8&ved=2ahUKEwjstojQ8_OCAxUfKEQIHTgcDzwQFnoECBUQAQ&url=https%3A%2F%2Fgithub.com%2Fdoubleunion%2Farooo&usg=AOvVaw1CUBhtDEr4RrjlUZnkoFe7&opi=89978449). This is a temporary fix to allow serving the site from GitHub pages.