### PR TITLE
Add support for tooltips in Calendar using Floating-UI library

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "sequoia-fabrica",
       "version": "0.1.0",
       "dependencies": {
+        "@floating-ui/react": "^0.26.11",
         "@fullcalendar/core": "^6.1.10",
         "@fullcalendar/daygrid": "^6.1.10",
         "@fullcalendar/icalendar": "^6.1.10",
@@ -16,7 +17,9 @@
         "@mdx-js/loader": "^3.0.0",
         "@mdx-js/react": "^3.0.0",
         "@next/mdx": "^14.0.3",
+        "@popperjs/core": "^2.11.8",
         "@rooks/use-window-size": "^4.11.2",
+        "@types/core-js": "^2.5.8",
         "@types/mdx": "^2.0.10",
         "dompurify": "^3.0.6",
         "ical.js": "^1.5.0",
@@ -2816,31 +2819,42 @@
       "dev": true
     },
     "node_modules/@floating-ui/core": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.5.2.tgz",
-      "integrity": "sha512-Ii3MrfY/GAIN3OhXNzpCKaLxHQfJF9qvwq/kEJYdqDxeIHa01K8sldugal6TmeeXl+WMvhv9cnVzUTaFFJF09A==",
-      "dev": true,
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.0.tgz",
+      "integrity": "sha512-PcF++MykgmTj3CIyOQbKA/hDzOAiqI3mhuoN44WRCopIs1sgoDoU4oty4Jtqaj/y3oDU6fnVSm4QG0a3t5i0+g==",
       "dependencies": {
-        "@floating-ui/utils": "^0.1.3"
+        "@floating-ui/utils": "^0.2.1"
       }
     },
     "node_modules/@floating-ui/dom": {
-      "version": "1.5.3",
-      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.5.3.tgz",
-      "integrity": "sha512-ClAbQnEqJAKCJOEbbLo5IUlZHkNszqhuxS4fHAVxRPXPya6Ysf2G8KypnYcOTpx6I8xcgF9bbHb6g/2KpbV8qA==",
-      "dev": true,
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.3.tgz",
+      "integrity": "sha512-RnDthu3mzPlQ31Ss/BTwQ1zjzIhr3lk1gZB1OC56h/1vEtaXkESrOqL5fQVMfXpwGtRwX+YsZBdyHtJMQnkArw==",
       "dependencies": {
-        "@floating-ui/core": "^1.4.2",
-        "@floating-ui/utils": "^0.1.3"
+        "@floating-ui/core": "^1.0.0",
+        "@floating-ui/utils": "^0.2.0"
+      }
+    },
+    "node_modules/@floating-ui/react": {
+      "version": "0.26.11",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.26.11.tgz",
+      "integrity": "sha512-fo01Cu+jzLDVG/AYAV2OtV6flhXvxP5rDaR1Fk8WWhtsFqwk478Dr2HGtB8s0HqQCsFWVbdHYpPjMiQiR/A9VA==",
+      "dependencies": {
+        "@floating-ui/react-dom": "^2.0.0",
+        "@floating-ui/utils": "^0.2.0",
+        "tabbable": "^6.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
       }
     },
     "node_modules/@floating-ui/react-dom": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.0.4.tgz",
-      "integrity": "sha512-CF8k2rgKeh/49UrnIBs4BdxPUV6vize/Db1d/YbCLyp9GiVZ0BEwf5AiDSxJRCr6yOkGqTFHtmrULxkEfYZ7dQ==",
-      "dev": true,
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.0.8.tgz",
+      "integrity": "sha512-HOdqOt3R3OGeTKidaLvJKcgg75S6tibQ3Tif4eyd91QnIJWr0NLvoXFpJA/j8HqkFSL68GDca9AuyWEHlhyClw==",
       "dependencies": {
-        "@floating-ui/dom": "^1.5.1"
+        "@floating-ui/dom": "^1.6.1"
       },
       "peerDependencies": {
         "react": ">=16.8.0",
@@ -2848,10 +2862,9 @@
       }
     },
     "node_modules/@floating-ui/utils": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.1.6.tgz",
-      "integrity": "sha512-OfX7E2oUDYxtBvsuS4e/jSn4Q9Qb6DzgeYtsAdkPZ47znpoNsMgZw0+tVijiv3uGNR6dgNlty6r9rzIzHjtd/A==",
-      "dev": true
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.1.tgz",
+      "integrity": "sha512-9TANp6GPoMtYzQdt54kfAyMmz1+osLlXdg2ENroU7zzrtflTLrrC/lgrIfaSe+Wu0b89GKccT7vxXA0MoAIO+Q=="
     },
     "node_modules/@fullcalendar/core": {
       "version": "6.1.11",
@@ -3624,6 +3637,15 @@
       },
       "engines": {
         "node": ">=8.9.0"
+      }
+    },
+    "node_modules/@popperjs/core": {
+      "version": "2.11.8",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
+      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/popperjs"
       }
     },
     "node_modules/@radix-ui/number": {
@@ -6023,6 +6045,11 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/core-js": {
+      "version": "2.5.8",
+      "resolved": "https://registry.npmjs.org/@types/core-js/-/core-js-2.5.8.tgz",
+      "integrity": "sha512-VgnAj6tIAhJhZdJ8/IpxdatM8G4OD3VWGlp6xIxUGENZlpbob9Ty4VVdC1FIEp0aK6DBscDDjyzy5FB60TuNqg=="
+    },
     "node_modules/@types/cross-spawn": {
       "version": "6.0.6",
       "resolved": "https://registry.npmjs.org/@types/cross-spawn/-/cross-spawn-6.0.6.tgz",
@@ -7857,13 +7884,13 @@
       "dev": true
     },
     "node_modules/body-parser": {
-      "version": "1.20.1",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.1.tgz",
-      "integrity": "sha512-jWi7abTbYwajOytWCQc37VulmWiRae5RyTpaCyDcS5/lMdtwSz5lOpDE67srw/HYe35f1z3fDQw+3txg7gNtWw==",
+      "version": "1.20.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.2.tgz",
+      "integrity": "sha512-ml9pReCu3M61kGlqoTm2umSXTlRTuGTx0bfYj+uIUKKYycG5NtSbeetV3faSU6R7ajOPw0g/J1PvK4qNy7s5bA==",
       "dev": true,
       "dependencies": {
         "bytes": "3.1.2",
-        "content-type": "~1.0.4",
+        "content-type": "~1.0.5",
         "debug": "2.6.9",
         "depd": "2.0.0",
         "destroy": "1.2.0",
@@ -7871,7 +7898,7 @@
         "iconv-lite": "0.4.24",
         "on-finished": "2.4.1",
         "qs": "6.11.0",
-        "raw-body": "2.5.1",
+        "raw-body": "2.5.2",
         "type-is": "~1.6.18",
         "unpipe": "1.0.0"
       },
@@ -8788,9 +8815,9 @@
       "dev": true
     },
     "node_modules/cookie": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
-      "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
+      "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
       "dev": true,
       "engines": {
         "node": ">= 0.6"
@@ -10608,17 +10635,17 @@
       }
     },
     "node_modules/express": {
-      "version": "4.18.2",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.18.2.tgz",
-      "integrity": "sha512-5/PsL6iGPdfQ/lKM1UuielYgv3BUoJfz1aUwU9vHZ+J7gyvwdQXFEBIEIaxeGf0GIcreATNyBExtalisDbuMqQ==",
+      "version": "4.19.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.19.2.tgz",
+      "integrity": "sha512-5T6nhjsT+EOMzuck8JjBHARTHfMht0POzlA60WV2pMD3gyXw2LZnZ+ueGdNxG+0calOJcWKbpFcuzLZ91YWq9Q==",
       "dev": true,
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
-        "body-parser": "1.20.1",
+        "body-parser": "1.20.2",
         "content-disposition": "0.5.4",
         "content-type": "~1.0.4",
-        "cookie": "0.5.0",
+        "cookie": "0.6.0",
         "cookie-signature": "1.0.6",
         "debug": "2.6.9",
         "depd": "2.0.0",
@@ -12187,9 +12214,9 @@
       }
     },
     "node_modules/ip": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.0.tgz",
-      "integrity": "sha512-WKa+XuLG1A1R0UWhl2+1XQSi+fZWMsYKffMZTTYsiZaUD8k2yDAj5atimTUD2TZkyCkNEeYE5NhFZmupOGtjYQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.1.tgz",
+      "integrity": "sha512-lJUL9imLTNi1ZfXT+DU6rBBdbiKGBuay9B6xGSPVjUeQwaH1RIGqef8RZkUtHioLmSNpPR5M4HVKJGm1j8FWVQ==",
       "dev": true
     },
     "node_modules/ipaddr.js": {
@@ -16269,9 +16296,9 @@
       }
     },
     "node_modules/raw-body": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.1.tgz",
-      "integrity": "sha512-qqJBtEyVgS0ZmPGdCFPWJ3FreoqvG4MVQln/kCgF7Olq95IbOp0/BWyMwbdtn4VTvkM8Y7khCQ2Xgk/tcrCXig==",
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
+      "integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
       "dev": true,
       "dependencies": {
         "bytes": "3.1.2",
@@ -18243,6 +18270,11 @@
       "integrity": "sha512-AsS729u2RHUfEra9xJrE39peJcc2stq2+poBXX8bcM08Y6g9j/i/PUzwNQqkaJde7Ntg1TO7bSREbR5sdosQ+g==",
       "dev": true
     },
+    "node_modules/tabbable": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.2.0.tgz",
+      "integrity": "sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew=="
+    },
     "node_modules/tailwindcss": {
       "version": "3.3.5",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.3.5.tgz",
@@ -19487,9 +19519,9 @@
       }
     },
     "node_modules/webpack-dev-middleware": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-6.1.1.tgz",
-      "integrity": "sha512-y51HrHaFeeWir0YO4f0g+9GwZawuigzcAdRNon6jErXy/SqV/+O6eaVAzDqE6t3e3NpGeR5CS+cCDaTC+V3yEQ==",
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-6.1.3.tgz",
+      "integrity": "sha512-A4ChP0Qj8oGociTs6UdlRUGANIGrCDL3y+pmQMc+dSsraXHCatFpmMey4mYELA+juqwUqwQsUgJJISXl1KWmiw==",
       "dev": true,
       "dependencies": {
         "colorette": "^2.0.10",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "build-storybook": "storybook build"
   },
   "dependencies": {
+    "@floating-ui/react": "^0.26.11",
     "@fullcalendar/core": "^6.1.10",
     "@fullcalendar/daygrid": "^6.1.10",
     "@fullcalendar/icalendar": "^6.1.10",
@@ -20,7 +21,9 @@
     "@mdx-js/loader": "^3.0.0",
     "@mdx-js/react": "^3.0.0",
     "@next/mdx": "^14.0.3",
+    "@popperjs/core": "^2.11.8",
     "@rooks/use-window-size": "^4.11.2",
+    "@types/core-js": "^2.5.8",
     "@types/mdx": "^2.0.10",
     "dompurify": "^3.0.6",
     "ical.js": "^1.5.0",

--- a/src/common/dateUtil.ts
+++ b/src/common/dateUtil.ts
@@ -1,0 +1,14 @@
+export function formatTime(date: Date): string {
+    const hours = date.getHours();
+    const minutes = date.getMinutes();;
+
+    let formattedTime: string;
+
+    if (hours >= 12) {
+        formattedTime = `${hours > 12 ? hours - 12 : hours}:${minutes < 10 ? '0' + minutes : minutes}PM`;
+    } else {
+        formattedTime = `${hours}:${minutes < 10 ? '0' + minutes : minutes}AM`;
+    }
+
+    return formattedTime;
+}

--- a/src/components/Calendar/Popover.tsx
+++ b/src/components/Calendar/Popover.tsx
@@ -1,0 +1,188 @@
+import * as React from "react";
+import {
+    useFloating,
+    autoUpdate,
+    offset,
+    flip,
+    shift,
+    useHover,
+    useDismiss,
+    useRole,
+    useInteractions,
+    useMergeRefs,
+    Placement,
+    FloatingPortal,
+    FloatingFocusManager,
+    useId
+} from "@floating-ui/react";
+
+interface PopoverOptions {
+    initialOpen?: boolean;
+    placement?: Placement;
+    modal?: boolean;
+    open?: boolean;
+    onOpenChange?: (open: boolean) => void;
+}
+
+export function usePopover({
+    initialOpen = false,
+    placement = "bottom",
+    modal,
+    open: controlledOpen,
+    onOpenChange: setControlledOpen
+}: PopoverOptions = {}) {
+    const [uncontrolledOpen, setUncontrolledOpen] = React.useState(initialOpen);
+    const [labelId, setLabelId] = React.useState<string | undefined>();
+    const [descriptionId, setDescriptionId] = React.useState<
+        string | undefined
+    >();
+
+    const open = controlledOpen ?? uncontrolledOpen;
+    const setOpen = setControlledOpen ?? setUncontrolledOpen;
+
+    const data = useFloating({
+        placement,
+        open,
+        onOpenChange: setOpen,
+        whileElementsMounted: autoUpdate,
+        middleware: [
+            offset(5),
+            flip({
+                crossAxis: placement.includes("-"),
+                fallbackAxisSideDirection: "end",
+                padding: 5
+            }),
+            shift({ padding: 5 })
+        ]
+    });
+
+    const context = data.context;
+
+    const click = useHover(context, {
+        enabled: controlledOpen == null
+    });
+    const dismiss = useDismiss(context);
+    const role = useRole(context);
+
+    const interactions = useInteractions([click, dismiss, role]);
+
+    return React.useMemo(
+        () => ({
+            open,
+            setOpen,
+            ...interactions,
+            ...data,
+            modal,
+            labelId,
+            descriptionId,
+            setLabelId,
+            setDescriptionId
+        }),
+        [open, setOpen, interactions, data, modal, labelId, descriptionId]
+    );
+}
+
+type ContextType =
+    | (ReturnType<typeof usePopover> & {
+        setLabelId: React.Dispatch<React.SetStateAction<string | undefined>>;
+        setDescriptionId: React.Dispatch<
+            React.SetStateAction<string | undefined>
+        >;
+    })
+    | null;
+
+const PopoverContext = React.createContext<ContextType>(null);
+
+export const usePopoverContext = () => {
+    const context = React.useContext(PopoverContext);
+
+    if (context == null) {
+        throw new Error("Popover components must be wrapped in <Popover />");
+    }
+
+    return context;
+};
+
+export function Popover({
+    children,
+    modal = false,
+    ...restOptions
+}: {
+    children: React.ReactNode;
+} & PopoverOptions) {
+    // This can accept any props as options, e.g. `placement`,
+    // or other positioning options.
+    const popover = usePopover({ modal, ...restOptions });
+    return (
+        <PopoverContext.Provider value={popover}>
+            {children}
+        </PopoverContext.Provider>
+    );
+}
+
+interface PopoverTriggerProps {
+    children: React.ReactNode;
+    asChild?: boolean;
+}
+
+export const PopoverTrigger = React.forwardRef<
+    HTMLElement,
+    React.HTMLProps<HTMLElement> & PopoverTriggerProps
+>(function PopoverTrigger({ children, asChild = false, ...props }, propRef) {
+    const context = usePopoverContext();
+    const childrenRef = (children as any).ref;
+    const ref = useMergeRefs([context.refs.setReference, propRef, childrenRef]);
+
+    // `asChild` allows the user to pass any element as the anchor
+    if (asChild && React.isValidElement(children)) {
+        return React.cloneElement(
+            children,
+            context.getReferenceProps({
+                ref,
+                ...props,
+                ...children.props,
+                "data-state": context.open ? "open" : "closed"
+            })
+        );
+    }
+
+    return (
+        <button
+            ref={ref}
+            type="button"
+            // The user can style the trigger based on the state
+            data-state={context.open ? "open" : "closed"}
+            {...context.getReferenceProps(props)}
+        >
+            {children}
+        </button>
+    );
+});
+
+export const PopoverContent = React.forwardRef<
+    HTMLDivElement,
+    React.HTMLProps<HTMLDivElement>
+>(function PopoverContent({ style, ...props }, propRef) {
+    const { context: floatingContext, ...context } = usePopoverContext();
+    const ref = useMergeRefs([context.refs.setFloating, propRef]);
+
+    if (!floatingContext.open) return null;
+
+    return (
+        <FloatingPortal>
+            <FloatingFocusManager context={floatingContext} modal={context.modal}>
+                <div
+                    ref={ref}
+                    style={{ ...context.floatingStyles, ...style }}
+                    aria-labelledby={context.labelId}
+                    aria-describedby={context.descriptionId}
+                    {...context.getFloatingProps(props)}
+                >
+                    <div>
+                        {props.children}
+                    </div>
+                </div>
+            </FloatingFocusManager>
+        </FloatingPortal>
+    );
+});


### PR DESCRIPTION
In the full calendar view, it's impossible to fit the entire event title. Truncate the string, and show the full name on hover.

<img width="773" alt="image" src="https://github.com/Sequoia-Fabrica/sequoia-fabrica-landing-page/assets/3757888/e6af2cb4-2e7d-4aad-a8ff-b836401fb02f">
